### PR TITLE
미션, 챌린지, 챌린지 이미지 엔티티 생성 및 전역 예외 처리 추가

### DIFF
--- a/src/main/java/com/chungnam/eco/challenge/domain/Challenge.java
+++ b/src/main/java/com/chungnam/eco/challenge/domain/Challenge.java
@@ -1,4 +1,80 @@
 package com.chungnam.eco.challenge.domain;
 
-public class Challenge {
+import com.chungnam.eco.common.entity.BaseTimeEntity;
+import com.chungnam.eco.mission.domain.Mission;
+import com.chungnam.eco.user.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "challenge")
+public class Challenge extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Lob
+    @Column(name = "submission_text")
+    private String submissionText;
+
+    @Column(name = "status")
+    private ChallengeStatus challengeStatus;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name="completed_at")
+    private LocalDateTime completedAt;
+
+    @Builder
+    public Challenge(Member member, Mission mission, String submissionText) {
+        this.member = member;
+        this.mission = mission;
+        this.submissionText = submissionText;
+        this.challengeStatus = ChallengeStatus.BEFORE; // 미션 진행전으로 초기화
+    }
+
+    /**
+     * 지정한 시각에 챌린지를 시작 상태로 전환합니다.
+     * @param startedAt 시작 시각
+     */
+    public void setStartedAt(LocalDateTime startedAt) {
+        this.startedAt = startedAt;
+        this.challengeStatus = ChallengeStatus.IN_PROGRESS; // 미션 진행
+    }
+
+
+    /**
+     * 지정한 시각에 챌린지를 완료 상태로 전환합니다.
+     * @param completedAt 시작 시각
+     */
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+        this.challengeStatus = ChallengeStatus.COMPLETED; // 미션 완료
+    }
+
 }

--- a/src/main/java/com/chungnam/eco/challenge/domain/ChallengeImage.java
+++ b/src/main/java/com/chungnam/eco/challenge/domain/ChallengeImage.java
@@ -1,4 +1,73 @@
 package com.chungnam.eco.challenge.domain;
 
-public class ChallengeImage {
+import com.chungnam.eco.challenge.exception.InvalidChallengeException;
+import com.chungnam.eco.common.entity.BaseTimeEntity;
+import com.chungnam.eco.common.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "challenge_image")
+public class ChallengeImage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "challenge_id", nullable = false)
+    private Challenge challenge;
+
+    @Lob
+    @Column(name = "original_name", nullable = false)
+    private String originalName;
+
+    @Column(name = "stored_name", nullable = false, unique = true)
+    private String storedName;
+
+    @Column(nullable = false, length = 1)
+    private Integer sort;
+
+    @Lob
+    @Column(nullable = false)
+    private String url;
+
+
+    @Builder
+    public ChallengeImage(Challenge challenge, String originalName, Integer sort) {
+        this.challenge = challenge;
+        this.originalName = originalName;
+        this.sort = sort != null ? sort : 1; // null-safe
+        this.storedName = generateStoredName();
+        this.url = generateUrl();
+    }
+
+    // UUID 자동생성
+    private String generateStoredName() {
+        return java.util.UUID.randomUUID().toString();
+    }
+
+    // 이미지 경로 생성
+    private String generateUrl() {
+        if (this.challenge == null || this.challenge.getId() == null) {
+            throw new InvalidChallengeException(ErrorCode.INVALID_CHALLENGE); // challenge 없을 경우 예외 처리
+        }
+        return "/images/" + this.challenge.getId() + "/" + this.storedName; // challenge id 로 폴더 생성 후 이미지 저장
+    }
+
 }

--- a/src/main/java/com/chungnam/eco/challenge/domain/ChallengeStatus.java
+++ b/src/main/java/com/chungnam/eco/challenge/domain/ChallengeStatus.java
@@ -1,0 +1,7 @@
+package com.chungnam.eco.challenge.domain;
+
+public enum ChallengeStatus {
+    BEFORE,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/com/chungnam/eco/challenge/exception/InvalidChallengeException.java
+++ b/src/main/java/com/chungnam/eco/challenge/exception/InvalidChallengeException.java
@@ -1,0 +1,12 @@
+package com.chungnam.eco.challenge.exception;
+
+import com.chungnam.eco.common.exception.BusinessException;
+import com.chungnam.eco.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidChallengeException extends BusinessException {
+    public InvalidChallengeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/chungnam/eco/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/chungnam/eco/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.chungnam.eco.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/chungnam/eco/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/chungnam/eco/common/entity/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.chungnam.eco.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at",updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/chungnam/eco/common/exception/BusinessException.java
+++ b/src/main/java/com/chungnam/eco/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.chungnam.eco.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    protected BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/chungnam/eco/common/exception/ErrorCode.java
+++ b/src/main/java/com/chungnam/eco/common/exception/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
     
     // 일반적인 에러
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 오류가 발생했습니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "S002", "잘못된 요청입니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "S002", "잘못된 요청입니다."),
+
+    // challenge가 존재하지 않을 때 에러
+    INVALID_CHALLENGE(HttpStatus.INTERNAL_SERVER_ERROR,"S003","challenge가 존재하지 않습니다.");
     
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/chungnam/eco/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chungnam/eco/common/exception/GlobalExceptionHandler.java
@@ -31,4 +31,25 @@ public class GlobalExceptionHandler {
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(errorResponse);
     }
+
+    // 커스텀 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> challengeHandleException(
+            BusinessException e,
+            HttpServletRequest request) {
+
+        log.error("Unexpected error occurred: ", e);
+
+        ErrorCode errorCode = e.getErrorCode();
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
 }

--- a/src/main/java/com/chungnam/eco/mission/domain/Mission.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/Mission.java
@@ -1,4 +1,54 @@
 package com.chungnam.eco.mission.domain;
 
-public class Mission {
+import com.chungnam.eco.common.entity.BaseTimeEntity;
+import jakarta.persistence.Access;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "mission")
+public class Mission extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Lob
+    @Column(name = "description",nullable = false)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private MissionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private MissionStatus status;
+
+    @Column(name = "reward_points", nullable = false)
+    private Integer rewardPoints;
+
+    @Builder
+    public Mission(String title, String description, MissionType type, MissionStatus status, Integer rewardPoints) {
+        this.title = title;
+        this.description = description;
+        this.type = type;
+        this.status = status;
+        this.rewardPoints = rewardPoints;
+    }
 }

--- a/src/main/java/com/chungnam/eco/mission/domain/Mission.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/Mission.java
@@ -44,11 +44,28 @@ public class Mission extends BaseTimeEntity {
     private Integer rewardPoints;
 
     @Builder
-    public Mission(String title, String description, MissionType type, MissionStatus status, Integer rewardPoints) {
+    public Mission(String title, String description, MissionType type, Integer rewardPoints) {
         this.title = title;
         this.description = description;
         this.type = type;
-        this.status = status;
+        this.status = MissionStatus.CREATE; // 생성으로 초기화
         this.rewardPoints = rewardPoints;
     }
+
+    /**
+     * 미션을 활성화 상태로 변경합니다.
+     */
+    public void activate() {
+        this.status = MissionStatus.ACTIVATE;
+    }
+
+    /**
+     * 미션을 삭제 상태로 변경합니다.
+     */
+    public void delete() {
+        this.status = MissionStatus.DELETE;
+    }
+
+
+
 }

--- a/src/main/java/com/chungnam/eco/mission/domain/MissionStatus.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/MissionStatus.java
@@ -1,0 +1,6 @@
+package com.chungnam.eco.mission.domain;
+
+public enum MissionStatus {
+    DAILY,
+    WEEKLY
+}

--- a/src/main/java/com/chungnam/eco/mission/domain/MissionStatus.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/MissionStatus.java
@@ -1,6 +1,7 @@
 package com.chungnam.eco.mission.domain;
 
 public enum MissionStatus {
-    DAILY,
-    WEEKLY
+    CREATE,
+    ACTIVATE,
+    DELETE
 }

--- a/src/main/java/com/chungnam/eco/mission/domain/MissionType.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/MissionType.java
@@ -1,0 +1,7 @@
+package com.chungnam.eco.mission.domain;
+
+public enum MissionType {
+    CREATE,
+    ACTIVATE,
+    DELETE
+}

--- a/src/main/java/com/chungnam/eco/mission/domain/MissionType.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/MissionType.java
@@ -1,7 +1,6 @@
 package com.chungnam.eco.mission.domain;
 
 public enum MissionType {
-    CREATE,
-    ACTIVATE,
-    DELETE
+    DAILY,
+    WEEKLY
 }


### PR DESCRIPTION
# 미션, 첼린지, 첼린지 이미지 엔티티 생성 및 전역 예외 처리 추가

## 작업 내용

- DB 설계에 따라 Mission, Challenge, ChallengeImage 엔티티를 추가하였습니다.
- BaseTimeEntity를 생성하여 모든 엔티티에 생성일/수정일이 자동으로 기록되도록 구성했습니다.
- BusinessException을 만들어 공통 예외 처리의 기반으로 사용하도록 하였습니다.
- InvalidChallengeException은 BusinessException을 상속하여 챌린지 유효성 검증 실패 시 발생하도록 구현했습니다.
- GlobalExceptionHandler에 BusinessException 처리 로직을 추가해 공통적으로 예외를 처리하도록 개선했습니다.
