### PR TITLE
#12 피드백 반영 후 수정

### DIFF
--- a/src/main/java/com/chungnam/eco/admin/controller/AdminChallengeController.java
+++ b/src/main/java/com/chungnam/eco/admin/controller/AdminChallengeController.java
@@ -33,7 +33,7 @@ public class AdminChallengeController {
      * @return 상태에 따른 Challenge 목록
      */
     @GetMapping("/challenges")
-    public ResponseEntity<?> getMissionAuthList(
+    public ResponseEntity<AllChallengeResponse> getMissionAuthList(
             @RequestParam(required = false) String status,
             @PageableDefault(size = 10, page = 0, sort = "startedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
@@ -52,7 +52,7 @@ public class AdminChallengeController {
      * @return Challenge 상세 정보와 이미지 목록
      */
     @GetMapping("/challenges/{challengeId}")
-    public ResponseEntity<?> getChallengeDetail(@PathVariable Long challengeId) {
+    public ResponseEntity<ChallengeDetailResponse> getChallengeDetail(@PathVariable Long challengeId) {
         ChallengeDto challengeDto = adminChallengeService.getChallenge(challengeId);
 
         List<String> challengeImageList = adminChallengeService.getChallengeImages(challengeId);

--- a/src/main/java/com/chungnam/eco/admin/controller/AdminMissionController.java
+++ b/src/main/java/com/chungnam/eco/admin/controller/AdminMissionController.java
@@ -31,7 +31,7 @@ public class AdminMissionController {
      * @return ResponseEntity(MissionMainResponse) 생성된 미션 정보
      */
     @PostMapping("/missions")
-    public ResponseEntity<?> createMission(@RequestBody CreateMissionRequest createMissionRequest) {
+    public ResponseEntity<MissionMainResponse> createMission(@RequestBody CreateMissionRequest createMissionRequest) {
 
         MissionDto missionDto = missionService.creatMission(createMissionRequest); // MissionDto 생성
         MissionMainResponse response = MissionMainResponse.success(missionDto);
@@ -47,7 +47,7 @@ public class AdminMissionController {
      */
 
     @PatchMapping("/missions/{missionId}/activate")
-    public ResponseEntity<?> activateMission(@PathVariable Long missionId) {
+    public ResponseEntity<MissionMainResponse> activateMission(@PathVariable Long missionId) {
 
         MissionDto missionDto = missionService.activateMission(missionId); // Mission status activate로 변경
         MissionMainResponse response = MissionMainResponse.success(missionDto);
@@ -63,7 +63,7 @@ public class AdminMissionController {
      * @return ResponseEntity(AllMissionResponse) 미션 목록
      */
     @GetMapping("/missions")
-    public ResponseEntity<?> getAllMissions(@RequestParam(required = false) String status) {
+    public ResponseEntity<AllMissionResponse> getAllMissions(@RequestParam(required = false) String status) {
 
         List<MissionDto> missionDtoList = missionService.findMissionList(status); // 상태값으로 미션 조회
         AllMissionResponse response = AllMissionResponse.success(missionDtoList);
@@ -78,7 +78,7 @@ public class AdminMissionController {
      * @return ResponseEntity(MissionMainResponse) 삭제된 미션 정보
      */
     @PatchMapping("/missions/{missionId}/delete")
-    public ResponseEntity<?> deleteMission(@PathVariable Long missionId) {
+    public ResponseEntity<MissionMainResponse> deleteMission(@PathVariable Long missionId) {
 
         MissionDto missionDto = missionService.deactivateMission(missionId); // Mission status delete로 변경
         MissionMainResponse response = MissionMainResponse.success(missionDto);
@@ -94,8 +94,8 @@ public class AdminMissionController {
      * @return ResponseEntity(MissionMainResponse) 수정된 미션 정보
      */
     @PatchMapping("/missions/{missionId}")
-    public ResponseEntity<?> editMission(@PathVariable Long missionId,
-                                         @RequestBody EditMissionRequest editMissionRequest) {
+    public ResponseEntity<MissionMainResponse> editMission(@PathVariable Long missionId,
+                                                           @RequestBody EditMissionRequest editMissionRequest) {
         MissionDto missionDto = missionService.editMission(missionId, editMissionRequest); // 미션 수정
         MissionMainResponse response = MissionMainResponse.success(missionDto);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/chungnam/eco/admin/service/AdminChallengeService.java
+++ b/src/main/java/com/chungnam/eco/admin/service/AdminChallengeService.java
@@ -6,8 +6,10 @@ import com.chungnam.eco.challenge.domain.ChallengeImage;
 import com.chungnam.eco.challenge.domain.ChallengeStatus;
 import com.chungnam.eco.challenge.repository.ChallengeImageJPARepository;
 import com.chungnam.eco.challenge.repository.ChallengeJPARepository;
+import com.chungnam.eco.common.exception.UserNotFoundException;
 import com.chungnam.eco.mission.domain.Mission;
 import com.chungnam.eco.user.domain.User;
+import com.chungnam.eco.user.repository.UserJPARepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ public class AdminChallengeService {
 
     private final ChallengeJPARepository challengeJPARepository;
     private final ChallengeImageJPARepository challengeImageJPARepository;
+    private final UserJPARepository userJPARepository;
 
     /**
      * 챌린지를 ID로 조회합니다.
@@ -109,6 +112,14 @@ public class AdminChallengeService {
                 .toList();
     }
 
+    @Transactional
+    public void supplyPoint(Long userId, Integer point) {
+        User user = userJPARepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new UserNotFoundException("User not found. : " + userId));
+
+        user.addPoint(point);
+    }
+
     /**
      * 특정 챌린지를 승인 처리합니다. 챌린지의 상태를 COMPLETED로 변경하고, 유저에게 포인트를 지급합니다.
      *
@@ -121,7 +132,8 @@ public class AdminChallengeService {
         User user = challenge.getUser();
         Mission mission = challenge.getMission();
         Integer point = mission.getRewardPoints();
-        user.SupplyPoint(point);
+
+        supplyPoint(user.getId(), point);
 
         challenge.setCompleted();
     }

--- a/src/main/java/com/chungnam/eco/mission/domain/Mission.java
+++ b/src/main/java/com/chungnam/eco/mission/domain/Mission.java
@@ -73,7 +73,7 @@ public class Mission extends BaseTimeEntity {
     /**
      * 미션을 삭제 상태로 변경합니다.
      */
-    public void delete() {
+    public void disable() {
         this.status = MissionStatus.DELETE;
     }
 

--- a/src/main/java/com/chungnam/eco/mission/service/MissionService.java
+++ b/src/main/java/com/chungnam/eco/mission/service/MissionService.java
@@ -75,7 +75,7 @@ public class MissionService {
     @Transactional
     public MissionDto deactivateMission(Long missionId) {
         Mission mission = findMissionById(missionId);
-        mission.delete(); // 미션 삭제
+        mission.disable(); // 미션 비활성화
         return MissionDto.from(mission);
     }
 

--- a/src/main/java/com/chungnam/eco/user/domain/User.java
+++ b/src/main/java/com/chungnam/eco/user/domain/User.java
@@ -75,13 +75,4 @@ public class User extends BaseTimeEntity {
         }
         this.point -= points;
     }
-
-     * 포인트 지급 메서드
-     *
-     * @param point 제공할 포인트
-     * @return User
-     */
-    public void SupplyPoint(Integer point) {
-        this.point += point;
-    }
 }

--- a/src/main/java/com/chungnam/eco/user/repository/UserJPARepository.java
+++ b/src/main/java/com/chungnam/eco/user/repository/UserJPARepository.java
@@ -1,38 +1,56 @@
 package com.chungnam.eco.user.repository;
 
 import com.chungnam.eco.user.domain.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserJPARepository extends JpaRepository<User, Long> {
-    
+
     /**
      * 이메일 존재 여부 확인
+     *
      * @param email 확인할 이메일
      * @return 존재하면 true, 없으면 false
      */
     boolean existsByEmail(String email);
-    
+
     /**
      * 닉네임 존재 여부 확인
+     *
      * @param nickname 확인할 닉네임
      * @return 존재하면 true, 없으면 false
      */
     boolean existsByNickname(String nickname);
-    
+
     /**
      * 이메일로 사용자 조회
+     *
      * @param email 조회할 이메일
      * @return 사용자 정보 (Optional)
      */
     Optional<User> findByEmail(String email);
-    
+
     /**
      * 닉네임으로 사용자 조회
+     *
      * @param nickname 조회할 닉네임
      * @return 사용자 정보 (Optional)
      */
     Optional<User> findByNickname(String nickname);
+
+    /**
+     * 비관적 락을 사용한 user 조회, 커밋 전까지 데이터 접근 불가
+     *
+     * @param id
+     * @return
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/test/java/com/chungnam/eco/user/service/UserPointServiceTest.java
+++ b/src/test/java/com/chungnam/eco/user/service/UserPointServiceTest.java
@@ -1,0 +1,66 @@
+package com.chungnam.eco.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.chungnam.eco.admin.service.AdminChallengeService;
+import com.chungnam.eco.config.TestContainerConfig;
+import com.chungnam.eco.user.domain.User;
+import com.chungnam.eco.user.domain.UserRole;
+import com.chungnam.eco.user.repository.UserJPARepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("포인트 차감, 적립 동시성 테스트")
+class UserPointServiceTest extends TestContainerConfig {
+
+    @Autowired
+    UserJPARepository userRepository;
+
+    @Autowired
+    AdminChallengeService adminChallengeService;
+
+    @Test
+    @DisplayName("동시성 체크 - 2개의 스레드가 동시에 포인트 적립")
+    void concurrencyCheck() throws InterruptedException {
+        // given
+        User user = User.builder()
+                .email("test@email.com")
+                .role(UserRole.USER)
+                .nickname("test")
+                .password("test")
+                .point(100)
+                .build();
+
+        userRepository.saveAndFlush(user);
+
+        int threadCount = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    adminChallengeService.supplyPoint(user.getId(), 100);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        User updatedUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        assertThat(updatedUser.getPoint()).isEqualTo(300); // 100 + 100 + 100
+    }
+}


### PR DESCRIPTION
## #12 피드백

### Mission 엔티티 메소드명 delete → disable로 변경
- 메소드명이 물리적 DB 삭제로 오인될 수 있어 disable로 변경
- 상태 플래그를 변경하는 논리적 삭제임을 명확히 표현

### 포인트 지급 시 동시성 제어를 위해 비관적 락 적용
- UserJPARepository에 @lock(PESSIMISTIC_WRITE)를 사용한 findByIdForUpdate 메서드 추가
- User 엔티티의 supplyPoint 메서드 제거하고 기존 addPoint 메서드로 통합
- AdminChallengeService에 supplyPoint 메서드 추가, approveChallenge에서 호출하도록 변경
- AdminChallengeService에 UserNotFoundException 처리 로직 추가
- 동시성 테스트 코드를 작성하여 결과 검증 (차감은 만들어지지 않아 지급 동시성만 체크 했습니다.) 





